### PR TITLE
[RHDM-2007] non-matching rule fires randomly and results in infinite-loop 

### DIFF
--- a/drools-core/src/main/java/org/drools/core/phreak/SegmentPropagator.java
+++ b/drools-core/src/main/java/org/drools/core/phreak/SegmentPropagator.java
@@ -27,7 +27,7 @@ import org.drools.core.reteoo.SegmentMemory;
 
 import static org.drools.core.phreak.AddRemoveRule.forceFlushLeftTuple;
 import static org.drools.core.phreak.AddRemoveRule.forceFlushWhenRiaNode;
-import static org.drools.core.reteoo.NodeTypeEnums.hasNodeMemory;
+import static org.drools.core.reteoo.NodeTypeEnums.AccumulateNode;
 
 public class SegmentPropagator {
 
@@ -131,7 +131,7 @@ public class SegmentPropagator {
                 break;
             default:
                 // no clash, so just add
-                if ( hasNodeMemory( childLeftTuple.getTupleSink() ) ) {
+                if ( childLeftTuple.getTupleSink().getType() == AccumulateNode ) {
                     trgLeftTuples.addInsert(childLeftTuple);
                 } else {
                     trgLeftTuples.addUpdate(childLeftTuple);

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/UnexpectedLoopTest.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/UnexpectedLoopTest.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.drools.compiler.integrationtests;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.drools.compiler.integrationtests.model.CalcFact;
+import org.drools.compiler.integrationtests.model.Item;
+import org.drools.compiler.integrationtests.model.RecordFact;
+import org.drools.testcoverage.common.util.KieBaseTestConfiguration;
+import org.drools.testcoverage.common.util.KieBaseUtil;
+import org.drools.testcoverage.common.util.TestParametersUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieBase;
+import org.kie.api.runtime.KieSession;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class UnexpectedLoopTest {
+
+    private final KieBaseTestConfiguration kieBaseTestConfiguration;
+
+    public UnexpectedLoopTest(final KieBaseTestConfiguration kieBaseTestConfiguration) {
+        this.kieBaseTestConfiguration = kieBaseTestConfiguration;
+    }
+
+    @Parameterized.Parameters(name = "KieBase type={0}")
+    public static Collection<Object[]> getParameters() {
+        return TestParametersUtil.getKieBaseCloudConfigurations(true);
+    }
+
+    @Test
+    public void joinFromFromPeerUpdate_shouldNotLoop() {
+
+        final KieBase kieBase = KieBaseUtil.getKieBaseFromClasspathResources(getClass(), kieBaseTestConfiguration,
+                                                                             "org/drools/compiler/integrationtests/joinFromFrom.drl");
+        final KieSession ksession = kieBase.newKieSession();
+        try {
+            RecordFact record1 = new RecordFact(null, 0);
+            Item item1 = new Item(null);
+            CalcFact calcFact = new CalcFact(new ArrayList<>(Arrays.asList(item1)), 4144);
+
+            ksession.insert("test");
+            ksession.insert(record1);
+            ksession.insert(item1);
+            ksession.insert(calcFact);
+
+            int fired = ksession.fireAllRules(10);
+
+            assertThat(fired).as("Unexpected loop detected. Expects firing R2 once").isEqualTo(1);
+        } finally {
+            ksession.dispose();
+        }
+    }
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/model/CalcFact.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/model/CalcFact.java
@@ -1,0 +1,34 @@
+package org.drools.compiler.integrationtests.model;
+
+import java.util.List;
+
+public class CalcFact {
+
+    private List<Item> itemList;
+    private int lineNumber;
+
+    public CalcFact(List<Item> itemList, int lineNumber) {
+        this.itemList = itemList;
+        this.lineNumber = lineNumber;
+    }
+
+    public List<Item> getItemList() {
+        return itemList;
+    }
+
+    public void setItemList(List<Item> itemList) {
+        this.itemList = itemList;
+    }
+
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    @Override
+    public String toString() {
+        return "CalcFact{" +
+                "itemList=" + itemList +
+                ", lineNumber=" + lineNumber +
+                '}';
+    }
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/model/Item.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/model/Item.java
@@ -1,0 +1,25 @@
+package org.drools.compiler.integrationtests.model;
+
+public class Item {
+
+    private String decomposedPointFlag;
+
+    public Item(String decomposedPointFlag) {
+        this.decomposedPointFlag = decomposedPointFlag;
+    }
+
+    public String getDecomposedPointFlag() {
+        return decomposedPointFlag;
+    }
+
+    public void setDecomposedPointFlag(String decomposedPointFlag) {
+        this.decomposedPointFlag = decomposedPointFlag;
+    }
+
+    @Override
+    public String toString() {
+        return "Item{" +
+                "pointFlag='" + decomposedPointFlag + '\'' +
+                '}';
+    }
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/model/RecordFact.java
+++ b/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/model/RecordFact.java
@@ -1,0 +1,34 @@
+package org.drools.compiler.integrationtests.model;
+
+import java.math.BigDecimal;
+
+public class RecordFact {
+
+    private BigDecimal decomposedPoint;
+    private int lineNumber;
+
+    public RecordFact(BigDecimal decomposedPoint, int lineNumber) {
+        this.decomposedPoint = decomposedPoint;
+        this.lineNumber = lineNumber;
+    }
+
+    public BigDecimal getDecomposedPoint() {
+        return decomposedPoint;
+    }
+
+    public void setDecomposedPoint(BigDecimal decomposedPoint) {
+        this.decomposedPoint = decomposedPoint;
+    }
+
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    @Override
+    public String toString() {
+        return "RecordFact{" +
+                ", decomposedPoint=" + decomposedPoint +
+                ", lineNumber=" + lineNumber +
+                '}';
+    }
+}

--- a/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/joinFromFrom.drl
+++ b/drools-test-coverage/test-compiler-integration/src/test/resources/org/drools/compiler/integrationtests/joinFromFrom.drl
@@ -1,0 +1,35 @@
+package org.drools.compiler.integrationtests;
+
+import org.drools.compiler.integrationtests.model.CalcFact;
+import org.drools.compiler.integrationtests.model.Item;
+import org.drools.compiler.integrationtests.model.RecordFact;
+
+dialect "mvel"
+
+rule R1
+	when
+        String()
+        CalcFact( $lineNumber : lineNumber, $itemList : itemList )
+        Integer()
+	then
+end
+
+rule R2
+	when
+        String()
+        $fact : CalcFact( $itemList : itemList )
+        $item : Item( decomposedPointFlag == null ) from $itemList
+        $record : RecordFact( decomposedPoint == null )
+        not RecordFact( lineNumber == $fact.lineNumber )
+	then
+        modify($record){
+          decomposedPoint = null
+        }
+        modify($item){
+          decomposedPointFlag = "1"
+        }
+        modify($fact){
+          itemList = $itemList
+        }
+        System.out.println("[DEBUG] after  $item=" + $item);
+end


### PR DESCRIPTION
* [KIE-686] fix peer update propagation for FromNode

* Update drools-test-coverage/test-compiler-integration/src/test/java/org/drools/compiler/integrationtests/UnexpectedLoopTest.java



* Fixed for Java 8 compatibility

---------

**Ports** 
This is a backport PR of https://github.com/apache/incubator-kie-drools/pull/5584 for 7.x
for 7.67.x -> https://github.com/kiegroup/drools/pull/23
for 7.67.x-blue -> https://github.com/kiegroup/drools/pull/22

**JIRA**: 
https://issues.redhat.com/browse/RHDM-2007

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

- <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

- <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native</b>

 - for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [drools|kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>

<!-- TODO to uncomment if activating the quarkus-3 rewrite PR job -->
<!-- <details>
<summary>
Quarkus-3 PR check is failing ... what to do ?
</summary>
The Quarkus 3 check is applying patches from the `.ci/environments/quarkus-3/patches`.

The first patch, called `0001_before_sh.patch`, is generated from Openrewrite `.ci/environments/quarkus-3/quarkus3.yml` recipe. The patch is created to speed up the check. But it may be that some changes in the PR broke this patch.  
No panic, there is an easy way to regenerate it. You just need to comment on the PR:
```
jenkins rewrite quarkus-3
```
and it should, after some minutes (~20/30min) apply a commit on the PR with the patch regenerated.

Other patches were generated manually. If any of it fails, you will need to manually update it... and push your changes.
</details> -->