### PR TITLE
Update PropertiesSheetListener.java

### DIFF
--- a/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/xls/PropertiesSheetListener.java
+++ b/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/xls/PropertiesSheetListener.java
@@ -40,7 +40,7 @@ public class PropertiesSheetListener implements DataListener {
 
     private static final String EMPTY_STRING   = "";
 
-    private final Map<Integer, String[]> _rowProperties = new HashMap<>();
+    private final Map<Integer, String[]> _rowProperties = new LinkedHashMap<>();
 
     private final CaseInsensitiveMap _properties = new CaseInsensitiveMap();
 


### PR DESCRIPTION
PR Overview:
_________________________________________________________________________________________________________
This PR fixes the flaky/non-deterministic behavior of the following test because it assumes the ordering.

[org.drools.decisiontable.parser.RuleWorksheetParseFromFileTest#testWorkbookParse](https://github.com/kiegroup/drools/blob/5e7a71380600e039a1ed41b994ab0cadaaf25753/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/RuleWorksheetParseFromFileTest.java#L73)

[org.drools.decisiontable.parser.RuleWorksheetParse2Test#packageLevelAttributesShouldNotBeDuplicated](https://github.com/kiegroup/drools/blob/5e7a71380600e039a1ed41b994ab0cadaaf25753/drools-decisiontables/src/test/java/org/drools/decisiontable/parser/RuleWorksheetParse2Test.java#L154)

Test Overview:
_________________________________________________________________________________________________________
In the above tests, the tests make an internal call to the PropertiesSheetListener.java.  PropertiesSheetListener file has _rowProperties map that has been initialized as HashMap which is flaky in nature. This causes the above tests to fail.

This flakiness was identified by the [nondex tool](https://github.com/TestingResearchIllinois/NonDex) created by the researchers of UIUC.

```
[ERROR]   RuleWorksheetParse2Test.packageLevelAttributesShouldNotBeDuplicated:165 
Expecting throwable message:
  "Multiple values for AGENDA-GROUP in cells [C4, C3]"
to contain:
  "C3, C4"
but did not.

[ERROR] Failures: 
[ERROR]   RuleWorksheetParseFromFileTest.testWorkbookParse:98 
Actual and expected have the same elements but not in the same order, at index 0 actual element was:
  "lah.di.dah"
whereas expected element was:
  "blah.class1"
```

You can reproduce the issue by running the following commands (you can reproduce the error for other tests by changing the test):

```
mvn install -pl  drools-decisiontables  -am -DskipTests
mvn test -pl drools-decisiontables  -Dtest=org.drools.decisiontable.parser.RuleWorksheetParseFromFileTest#testWorkbookParse
mvn -pl drools-decisiontables edu.illinois:index-maven-plugin:2.1.1:nondex -Dtest=org.drools.decisiontable.parser.RuleWorksheetParseFromFileTest#testWorkbookParse
```

Fix:
_________________________________________________________________________________________________________
To fix the issue I have changed the HashSet with LinkedHashSet which is deterministic in nature.

https://github.com/njain2208/drools/blob/87b5099f8bde04b66078cb0daa09939c5755ebca/drools-decisiontables/src/main/java/org/drools/decisiontable/parser/xls/PropertiesSheetListener.java#L44